### PR TITLE
feat: add per-file commit count metric

### DIFF
--- a/.idea/mcpServer.xml
+++ b/.idea/mcpServer.xml
@@ -9,5 +9,6 @@
         <option value="get_notifications" />
       </set>
     </option>
+    <option name="port" value="8643" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
         intellijIdeaCommunity("2024.2.3")
         bundledPlugin("com.intellij.java")
         instrumentationTools()
+        pluginVerifier()
     }
 }
 
@@ -40,7 +41,9 @@ intellijPlatform {
     }
     pluginVerification {
         ides {
-            recommended()
+            // Pin to a known-released IDE to avoid flaky `recommended()` picking
+            // versions whose tarballs are not yet published to the download mirror.
+            ide(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaCommunity, "2024.2.3")
         }
     }
     buildSearchableOptions = false

--- a/src/main/kotlin/com/github/projectstats/GitCommitCountCalculator.kt
+++ b/src/main/kotlin/com/github/projectstats/GitCommitCountCalculator.kt
@@ -1,0 +1,104 @@
+package com.github.projectstats
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Counts, per file, how many commits reachable from HEAD touched it.
+ *
+ * Strategy: one `git log --pretty=format: --name-only` invocation per distinct git
+ * repository root found among the project's content roots. Output lists every file
+ * touched by every commit (one line per file per commit); we simply tally occurrences.
+ *
+ * Fails gracefully when `git` is missing, the project is not a git repository, or the
+ * subprocess errors — the metric returns 0 for every file in those cases.
+ */
+object GitCommitCountCalculator {
+
+    private val LOG = Logger.getInstance(GitCommitCountCalculator::class.java)
+    private const val PROCESS_TIMEOUT_SECONDS = 120L
+
+    fun compute(project: Project, indicator: ProgressIndicator?): Map<String, Int> {
+        val roots = discoverGitRoots(project)
+        if (roots.isEmpty()) return emptyMap()
+        val result = HashMap<String, Int>(4096)
+        for (root in roots) {
+            indicator?.checkCanceled()
+            indicator?.text2 = "Reading git history for $root"
+            try {
+                readGitLog(root, result, indicator)
+            } catch (e: Throwable) {
+                if (e is InterruptedException) throw e
+                LOG.info("git log failed for $root: ${e.message}")
+            }
+        }
+        return result
+    }
+
+    private fun discoverGitRoots(project: Project): List<String> {
+        val rootManager = ProjectRootManager.getInstance(project)
+        val candidates = LinkedHashSet<String>()
+        project.basePath?.let { candidates += it }
+        for (cr in rootManager.contentRoots) candidates += cr.path
+        val roots = LinkedHashSet<String>()
+        for (c in candidates) findGitRoot(c)?.let { roots += it }
+        return roots.toList()
+    }
+
+    private fun findGitRoot(startPath: String): String? {
+        var dir: File? = File(startPath)
+        while (dir != null) {
+            // `.git` is a directory in regular repos and a file in worktrees/submodules.
+            if (File(dir, ".git").exists()) return dir.absolutePath.replace('\\', '/')
+            dir = dir.parentFile
+        }
+        return null
+    }
+
+    private fun readGitLog(
+        repoRoot: String,
+        accum: MutableMap<String, Int>,
+        indicator: ProgressIndicator?,
+    ) {
+        val pb = ProcessBuilder(
+            "git",
+            "-c", "core.quotePath=false",
+            "-C", repoRoot,
+            "log",
+            "--pretty=format:",
+            "--name-only",
+            "HEAD",
+        )
+        pb.redirectErrorStream(false)
+        val proc: Process = try {
+            pb.start()
+        } catch (e: IOException) {
+            LOG.info("Could not start git for $repoRoot: ${e.message}")
+            return
+        }
+        try {
+            proc.inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
+                var lines = 0
+                while (true) {
+                    val line = reader.readLine() ?: break
+                    if (line.isNotEmpty()) {
+                        val abs = "$repoRoot/$line"
+                        accum.merge(abs, 1, Int::plus)
+                    }
+                    if (++lines and 0x3FFF == 0) indicator?.checkCanceled()
+                }
+            }
+            if (!proc.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                LOG.info("git log timed out for $repoRoot after ${PROCESS_TIMEOUT_SECONDS}s")
+            }
+        } finally {
+            if (proc.isAlive) proc.destroyForcibly()
+        }
+    }
+}

--- a/src/main/kotlin/com/github/projectstats/Model.kt
+++ b/src/main/kotlin/com/github/projectstats/Model.kt
@@ -26,6 +26,7 @@ data class FileStat(
     val codeLines: Int,
     val complexity: Int,
     val sizeBytes: Long,
+    val commitCount: Int = 0,
     val fileCount: Int = 1,
 )
 
@@ -40,6 +41,7 @@ data class StatGroup(
     val complexity: Long,
     val sizeBytes: Long,
     val fileCount: Long,
+    val commitCount: Long,
     val children: List<StatGroup> = emptyList(),
 ) {
     fun value(metric: Metric): Long = when (metric) {
@@ -49,6 +51,7 @@ data class StatGroup(
         Metric.COMPLEXITY -> complexity
         Metric.SIZE -> sizeBytes
         Metric.FILE_COUNT -> fileCount
+        Metric.COMMIT_COUNT -> commitCount
     }
 }
 
@@ -58,7 +61,8 @@ enum class Metric(val display: String) {
     CODE_LOC("Code LOC"),
     COMPLEXITY("Complexity"),
     SIZE("File size"),
-    FILE_COUNT("File count");
+    FILE_COUNT("File count"),
+    COMMIT_COUNT("Commits");
 
     override fun toString() = display
 }
@@ -83,5 +87,6 @@ data class ScanResult(
     val complexity: Long,
     val sizeBytes: Long,
     val fileCount: Long,
+    val commitCount: Long,
     val scannedMillis: Long,
 )

--- a/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
@@ -13,6 +13,9 @@ import com.intellij.openapi.vfs.VirtualFileVisitor
 import org.jetbrains.jps.model.java.JavaResourceRootType
 import org.jetbrains.jps.model.java.JavaSourceRootType
 import org.jetbrains.jps.model.module.JpsModuleSourceRootType
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 object ProjectScanner {
 
@@ -26,14 +29,6 @@ object ProjectScanner {
 
         indicator?.text = "Scanning project files"
 
-        val files = ArrayList<FileStat>(4096)
-        var totalLines = 0L
-        var nonBlank = 0L
-        var codeL = 0L
-        var complexityTotal = 0L
-        var size = 0L
-        var commitsTotal = 0L
-
         val rootManager = ProjectRootManager.getInstance(project)
         val fileIndex = rootManager.fileIndex
         val projectBase: VirtualFile? = project.baseDir
@@ -42,8 +37,9 @@ object ProjectScanner {
         roots.addAll(rootManager.contentRoots)
         if (projectBase != null) roots.add(projectBase)
 
+        // Phase 1: walk VFS (fast, sequential) to collect files.
+        val toProcess = ArrayList<VirtualFile>(4096)
         val seenPaths = HashSet<String>(4096)
-        var visited = 0
         for (root in roots) {
             indicator?.checkCanceled()
             VfsUtilCore.visitChildrenRecursively(root, object : VirtualFileVisitor<Any?>() {
@@ -58,26 +54,64 @@ object ProjectScanner {
                         ) return false
                         return true
                     }
-                    if (!seenPaths.add(file.path)) return true
-                    visited++
-                    if (visited % 200 == 0) {
-                        indicator?.text2 = "Scanning ${file.presentableUrl}"
-                    }
-                    val baseStat = ReadAction.compute<FileStat?, RuntimeException> {
-                        classify(file, project, fileIndex, projectBase)
-                    } ?: return true
-                    val stat = if (commitCounts.isEmpty()) baseStat
-                    else baseStat.copy(commitCount = commitCounts[file.path] ?: 0)
-                    files += stat
-                    totalLines += stat.totalLines
-                    nonBlank += stat.nonBlankLines
-                    codeL += stat.codeLines
-                    complexityTotal += stat.complexity
-                    size += stat.sizeBytes
-                    commitsTotal += stat.commitCount
+                    if (seenPaths.add(file.path)) toProcess += file
                     return true
                 }
             })
+        }
+
+        // Phase 2: classify in parallel. ReadAction is a shared read lock — multiple workers OK.
+        val parallelism = Runtime.getRuntime().availableProcessors().coerceIn(2, 8)
+        val executor = Executors.newFixedThreadPool(parallelism) { r ->
+            Thread(r, "project-stats-scanner").apply { isDaemon = true }
+        }
+
+        val files = ArrayList<FileStat>(toProcess.size)
+        var totalLines = 0L
+        var nonBlank = 0L
+        var codeL = 0L
+        var complexityTotal = 0L
+        var size = 0L
+        var commitsTotal = 0L
+        val progressStep = (toProcess.size / 100).coerceAtLeast(50)
+
+        try {
+            val futures = toProcess.map { file ->
+                executor.submit(Callable<FileStat?> {
+                    ReadAction.compute<FileStat?, RuntimeException> {
+                        classify(file, project, fileIndex, projectBase)
+                    }?.let { base ->
+                        if (commitCounts.isEmpty()) base
+                        else base.copy(commitCount = commitCounts[file.path] ?: 0)
+                    }
+                })
+            }
+            var done = 0
+            for ((idx, f) in futures.withIndex()) {
+                indicator?.checkCanceled()
+                val stat = try {
+                    f.get()
+                } catch (e: java.util.concurrent.ExecutionException) {
+                    val cause = e.cause
+                    if (cause is RuntimeException) throw cause
+                    throw RuntimeException(cause ?: e)
+                }
+                done++
+                if (done % progressStep == 0) {
+                    indicator?.text2 = "Scanning ${toProcess[idx].presentableUrl}"
+                }
+                if (stat == null) continue
+                files += stat
+                totalLines += stat.totalLines
+                nonBlank += stat.nonBlankLines
+                codeL += stat.codeLines
+                complexityTotal += stat.complexity
+                size += stat.sizeBytes
+                commitsTotal += stat.commitCount
+            }
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(2, TimeUnit.SECONDS)
         }
 
         return ScanResult(
@@ -191,10 +225,14 @@ object ProjectScanner {
 
         // PSI-based complexity is more accurate for Java/Kotlin (handles operators, no false positives
         // from string literals). Falls back to the keyword count already computed above for other languages.
-        // Binary files (e.g. .class) have no source PSI tree — skip to avoid compiled-PSI walking errors.
+        // Restrict to extensions we actually treat as code to avoid parsing JSON/XML/YAML/MD trees that
+        // yield no branches but still cost CPU. Binary files are also skipped.
         if (!isBinary) {
-            val psiComplexity = PsiComplexityCalculator.calculate(file, project)
-            if (psiComplexity != null) complexity = psiComplexity
+            val ext = file.extension?.lowercase() ?: ""
+            if (DECISION_KEYWORDS.containsKey(ext)) {
+                val psiComplexity = PsiComplexityCalculator.calculate(file, project)
+                if (psiComplexity != null) complexity = psiComplexity
+            }
         }
 
         return FileStat(

--- a/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
@@ -20,12 +20,19 @@ object ProjectScanner {
 
     fun scan(project: Project, indicator: ProgressIndicator?): ScanResult {
         val started = System.currentTimeMillis()
+
+        indicator?.text = "Reading git history"
+        val commitCounts: Map<String, Int> = GitCommitCountCalculator.compute(project, indicator)
+
+        indicator?.text = "Scanning project files"
+
         val files = ArrayList<FileStat>(4096)
         var totalLines = 0L
         var nonBlank = 0L
         var codeL = 0L
         var complexityTotal = 0L
         var size = 0L
+        var commitsTotal = 0L
 
         val rootManager = ProjectRootManager.getInstance(project)
         val fileIndex = rootManager.fileIndex
@@ -56,15 +63,18 @@ object ProjectScanner {
                     if (visited % 200 == 0) {
                         indicator?.text2 = "Scanning ${file.presentableUrl}"
                     }
-                    val stat = ReadAction.compute<FileStat?, RuntimeException> {
+                    val baseStat = ReadAction.compute<FileStat?, RuntimeException> {
                         classify(file, project, fileIndex, projectBase)
                     } ?: return true
+                    val stat = if (commitCounts.isEmpty()) baseStat
+                    else baseStat.copy(commitCount = commitCounts[file.path] ?: 0)
                     files += stat
                     totalLines += stat.totalLines
                     nonBlank += stat.nonBlankLines
                     codeL += stat.codeLines
                     complexityTotal += stat.complexity
                     size += stat.sizeBytes
+                    commitsTotal += stat.commitCount
                     return true
                 }
             })
@@ -78,6 +88,7 @@ object ProjectScanner {
             complexity = complexityTotal,
             sizeBytes = size,
             fileCount = files.size.toLong(),
+            commitCount = commitsTotal,
             scannedMillis = System.currentTimeMillis() - started,
         )
     }

--- a/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
@@ -191,8 +191,11 @@ object ProjectScanner {
 
         // PSI-based complexity is more accurate for Java/Kotlin (handles operators, no false positives
         // from string literals). Falls back to the keyword count already computed above for other languages.
-        val psiComplexity = PsiComplexityCalculator.calculate(file, project)
-        if (psiComplexity != null) complexity = psiComplexity
+        // Binary files (e.g. .class) have no source PSI tree — skip to avoid compiled-PSI walking errors.
+        if (!isBinary) {
+            val psiComplexity = PsiComplexityCalculator.calculate(file, project)
+            if (psiComplexity != null) complexity = psiComplexity
+        }
 
         return FileStat(
             relativePath = relPath(file, projectBase),

--- a/src/main/kotlin/com/github/projectstats/ProjectStatsPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectStatsPanel.kt
@@ -1,10 +1,12 @@
 package com.github.projectstats
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.AnimatedIcon
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
@@ -13,8 +15,11 @@ import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
+import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.FlowLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JButton
@@ -38,9 +43,19 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
     private val includeGenerated = JCheckBox("Generated", false)
     private val includeResources = JCheckBox("Resources", true)
     private val includeOther = JCheckBox("Other", true)
-    private val refreshBtn = JButton("Refresh")
-    private val upBtn = JButton("↑ Up")
+    private val refreshBtn = JButton(AllIcons.Actions.Execute).apply {
+        toolTipText = "Scan project"
+        isFocusable = false
+        isBorderPainted = false
+        isContentAreaFilled = false
+        margin = JBUI.emptyInsets()
+        putClientProperty("JButton.buttonType", "toolBarButton")
+    }
     private val summary = JBLabel(" ")
+    private val breadcrumbRow = JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
+        border = JBUI.Borders.emptyTop(2)
+        isVisible = false
+    }
 
     private val treemap = TreemapPanel()
     private val stackedBar = StackedBarPanel()
@@ -50,6 +65,7 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
     private var scanResult: ScanResult? = null
     private var rootGroups: List<StatGroup> = emptyList()
     private var currentColorFn: (StatGroup) -> Color = { JBColor.GRAY }
+    private var scanning: Boolean = false
 
     init {
         border = JBUI.Borders.empty(4)
@@ -65,13 +81,10 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
         toolbar.add(includeGenerated)
         toolbar.add(includeResources)
         toolbar.add(includeOther)
-        toolbar.add(Box.createHorizontalStrut(8))
-        toolbar.add(refreshBtn)
-        toolbar.add(upBtn)
 
         val header = JPanel(BorderLayout())
         header.add(toolbar, BorderLayout.NORTH)
-        header.add(summary, BorderLayout.SOUTH)
+        header.add(breadcrumbRow, BorderLayout.SOUTH)
 
         val barPanel = JPanel(BorderLayout()).apply {
             border = JBUI.Borders.emptyTop(4)
@@ -91,11 +104,17 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
             dividerSize = 4
         }
 
+        val footer = JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.emptyTop(4)
+            add(summary, BorderLayout.CENTER)
+            add(refreshBtn, BorderLayout.EAST)
+        }
+
         add(header, BorderLayout.NORTH)
         add(split, BorderLayout.CENTER)
+        add(footer, BorderLayout.SOUTH)
 
         refreshBtn.addActionListener { runScan() }
-        upBtn.addActionListener { treemap.popDrill() }
         groupByBox.addActionListener { refreshViews() }
         metricBox.addActionListener { refreshViews() }
         includeTests.addActionListener { refreshViews() }
@@ -124,7 +143,7 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
     }
 
     fun runScan() {
-        refreshBtn.isEnabled = false
+        setScanning(true)
         summary.text = "Scanning…"
         object : Task.Backgroundable(project, "Computing project statistics", true) {
             override fun run(indicator: ProgressIndicator) {
@@ -133,35 +152,44 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
                 val result = ProjectScanner.scan(project, indicator)
                 ApplicationManager.getApplication().invokeLater {
                     scanResult = result
-                    refreshBtn.isEnabled = true
+                    setScanning(false)
                     refreshViews()
                 }
             }
 
             override fun onCancel() {
                 ApplicationManager.getApplication().invokeLater {
-                    refreshBtn.isEnabled = true
+                    setScanning(false)
                     summary.text = "Scan cancelled."
                 }
             }
 
             override fun onThrowable(error: Throwable) {
                 ApplicationManager.getApplication().invokeLater {
-                    refreshBtn.isEnabled = true
+                    setScanning(false)
                     summary.text = "Scan failed: ${error.message}"
                 }
             }
         }.queue()
     }
 
+    private fun setScanning(running: Boolean) {
+        scanning = running
+        refreshBtn.icon = if (running) AnimatedIcon.Default.INSTANCE else AllIcons.Actions.Execute
+        refreshBtn.toolTipText = if (running) "Scanning…" else "Scan project"
+        refreshBtn.isEnabled = !running
+    }
+
     private fun refreshViews() {
         val result = scanResult ?: run {
-            summary.text = "Click Refresh to scan the project."
+            summary.text = "Click the play button to scan the project."
             rootGroups = emptyList()
             currentColorFn = { JBColor.GRAY }
+            treemap.setSingleClickDrill(false)
             treemap.setData(emptyList(), Metric.LOC, currentColorFn)
             stackedBar.setData(emptyList(), Metric.LOC) { JBColor.GRAY }
             tableModel.update(emptyList(), Metric.LOC)
+            updateBreadcrumbs()
             return
         }
         val groupBy = groupByBox.selectedItem as GroupBy
@@ -180,6 +208,7 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
             else -> { g -> hashColor(g.key) }
         }
         rootGroups = groups
+        treemap.setSingleClickDrill(groupBy == GroupBy.DIRECTORY)
         // setData clears drill internally; we then render the (now-root) level into the table/bar.
         treemap.setData(groups, metric, currentColorFn)
         applyDrill(null)
@@ -214,8 +243,44 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
             append("Size: ${humanBytes(scopeSize)} | ")
             append("Scan: ${result.scannedMillis} ms | ")
             append("Shown (${metric.display}): ${format(metric, totalMetric)}")
-            if (treemap.currentPath().isNotEmpty()) append(" | Drill: ${treemap.currentPath()}")
         }
+        updateBreadcrumbs()
+    }
+
+    private fun updateBreadcrumbs() {
+        breadcrumbRow.removeAll()
+        val isDir = (groupByBox.selectedItem as? GroupBy) == GroupBy.DIRECTORY
+        if (!isDir) {
+            breadcrumbRow.isVisible = false
+            breadcrumbRow.revalidate()
+            breadcrumbRow.repaint()
+            return
+        }
+        breadcrumbRow.isVisible = true
+        breadcrumbRow.add(JLabel("Path:"))
+        breadcrumbRow.add(crumbLabel("<project>", 0))
+        val depth = treemap.drillDepth()
+        for (i in 0 until depth) {
+            breadcrumbRow.add(JLabel("/"))
+            breadcrumbRow.add(crumbLabel(treemap.drillStepDisplay(i), i + 1))
+        }
+        breadcrumbRow.revalidate()
+        breadcrumbRow.repaint()
+    }
+
+    private fun crumbLabel(text: String, targetDepth: Int): JLabel {
+        val isCurrent = targetDepth == treemap.drillDepth()
+        val label = JLabel(if (isCurrent) "<html><b>$text</b></html>" else "<html><a href=''>$text</a></html>")
+        if (!isCurrent) {
+            label.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            label.toolTipText = "Go to $text"
+            label.addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    treemap.popToDepth(targetDepth)
+                }
+            })
+        }
+        return label
     }
 
     private fun categoryColor(key: String): Color = when (key) {

--- a/src/main/kotlin/com/github/projectstats/ProjectStatsPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectStatsPanel.kt
@@ -202,6 +202,7 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
         val scopeCode = drilled?.codeLines ?: result.codeLines
         val scopeCplx = drilled?.complexity ?: result.complexity
         val scopeSize = drilled?.sizeBytes ?: result.sizeBytes
+        val scopeCommits = drilled?.commitCount ?: result.commitCount
         val totalMetric = shown.sumOf { it.value(metric) }
         summary.text = buildString {
             append("Files: %,d | ".format(scopeFiles))
@@ -209,6 +210,7 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
             append("Non-blank: %,d | ".format(scopeNonBlank))
             append("Code LOC: %,d | ".format(scopeCode))
             append("Complexity: %,d | ".format(scopeCplx))
+            append("Commits: %,d | ".format(scopeCommits))
             append("Size: ${humanBytes(scopeSize)} | ")
             append("Scan: ${result.scannedMillis} ms | ")
             append("Shown (${metric.display}): ${format(metric, totalMetric)}")
@@ -232,8 +234,6 @@ private class StatsTableModel : AbstractTableModel() {
     private var total: Long = 0
     private var metric: Metric = Metric.LOC
 
-    private val cols = arrayOf("Name", "Files", "LOC", "Non-blank", "Size", "% of $ $", "Children")
-
     fun update(groups: List<StatGroup>, metric: Metric) {
         this.rows = groups
         this.metric = metric
@@ -242,7 +242,7 @@ private class StatsTableModel : AbstractTableModel() {
     }
 
     override fun getRowCount(): Int = rows.size
-    override fun getColumnCount(): Int = 9
+    override fun getColumnCount(): Int = 10
     override fun getColumnName(column: Int): String = when (column) {
         0 -> "Name"
         1 -> "Files"
@@ -250,16 +250,17 @@ private class StatsTableModel : AbstractTableModel() {
         3 -> "Non-blank"
         4 -> "Code LOC"
         5 -> "Complexity"
-        6 -> "Size"
-        7 -> "% of ${metric.display}"
-        8 -> "Children"
+        6 -> "Commits"
+        7 -> "Size"
+        8 -> "% of ${metric.display}"
+        9 -> "Children"
         else -> ""
     }
 
     override fun getColumnClass(columnIndex: Int): Class<*> = when (columnIndex) {
-        1, 2, 3, 4, 5, 8 -> java.lang.Long::class.java
-        6 -> java.lang.Long::class.java
-        7 -> java.lang.Double::class.java
+        1, 2, 3, 4, 5, 6, 9 -> java.lang.Long::class.java
+        7 -> java.lang.Long::class.java
+        8 -> java.lang.Double::class.java
         else -> String::class.java
     }
 
@@ -272,9 +273,10 @@ private class StatsTableModel : AbstractTableModel() {
             3 -> r.nonBlankLines
             4 -> r.codeLines
             5 -> r.complexity
-            6 -> r.sizeBytes
-            7 -> if (total > 0) 100.0 * r.value(metric) / total else 0.0
-            8 -> r.children.size.toLong()
+            6 -> r.commitCount
+            7 -> r.sizeBytes
+            8 -> if (total > 0) 100.0 * r.value(metric) / total else 0.0
+            9 -> r.children.size.toLong()
             else -> ""
         }
     }

--- a/src/main/kotlin/com/github/projectstats/PsiComplexityCalculator.kt
+++ b/src/main/kotlin/com/github/projectstats/PsiComplexityCalculator.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiRecursiveElementVisitor
+import com.intellij.psi.impl.compiled.ClsFileImpl
 import com.siyeh.ig.classmetrics.CyclomaticComplexityVisitor
 
 /**
@@ -24,6 +25,8 @@ import com.siyeh.ig.classmetrics.CyclomaticComplexityVisitor
 object PsiComplexityCalculator {
     fun calculate(file: VirtualFile, project: Project): Int? {
         val psiFile = PsiManager.getInstance(project).findFile(file) ?: return null
+        // Compiled .class files must not be walked with a recursive visitor — too slow and logs errors.
+        if (psiFile is ClsFileImpl) return null
         // Plain text / unknown files have no real PSI tree — let the keyword fallback handle them.
         if (psiFile.language == PlainTextLanguage.INSTANCE) return null
         return when (psiFile) {

--- a/src/main/kotlin/com/github/projectstats/StatsAggregator.kt
+++ b/src/main/kotlin/com/github/projectstats/StatsAggregator.kt
@@ -39,7 +39,8 @@ object StatsAggregator {
         var code: Long = 0,
         var complexity: Long = 0,
         var size: Long = 0,
-        var count: Long = 0
+        var count: Long = 0,
+        var commits: Long = 0,
     )
 
     private inline fun flatGroup(files: List<FileStat>, keyOf: (FileStat) -> String): List<StatGroup> {
@@ -52,9 +53,10 @@ object StatsAggregator {
             acc.complexity += f.complexity
             acc.size += f.sizeBytes
             acc.count += 1
+            acc.commits += f.commitCount
         }
         return byKey.entries.map { (k, v) ->
-            StatGroup(k, v.total, v.nonBlank, v.code, v.complexity, v.size, v.count)
+            StatGroup(k, v.total, v.nonBlank, v.code, v.complexity, v.size, v.count, v.commits)
         }.sortedByDescending { it.totalLines }
     }
 
@@ -72,6 +74,7 @@ object StatsAggregator {
             var complexity: Long = 0,
             var size: Long = 0,
             var count: Long = 0,
+            var commits: Long = 0,
             var isFile: Boolean = false,
         )
 
@@ -83,6 +86,7 @@ object StatsAggregator {
             root.total += f.totalLines; root.nonBlank += f.nonBlankLines
             root.code += f.codeLines; root.complexity += f.complexity
             root.size += f.sizeBytes; root.count += 1
+            root.commits += f.commitCount
             for ((idx, part) in parts.withIndex()) {
                 node = node.children.getOrPut(part) { Node(part) }
                 node.total += f.totalLines
@@ -91,13 +95,14 @@ object StatsAggregator {
                 node.complexity += f.complexity
                 node.size += f.sizeBytes
                 node.count += 1
+                node.commits += f.commitCount
                 if (idx == parts.lastIndex) node.isFile = true
             }
         }
 
         fun convert(n: Node): StatGroup {
             val kids = n.children.values.map { convert(it) }.sortedByDescending { it.totalLines }
-            return StatGroup(n.name, n.total, n.nonBlank, n.code, n.complexity, n.size, n.count, kids)
+            return StatGroup(n.name, n.total, n.nonBlank, n.code, n.complexity, n.size, n.count, n.commits, kids)
         }
         // Return the top-level children (under <project>); treemap presents them as roots.
         return convert(root).children

--- a/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
@@ -284,4 +284,5 @@ fun format(metric: Metric, value: Long): String = when (metric) {
     Metric.LOC, Metric.NON_BLANK_LOC, Metric.CODE_LOC -> "%,d lines".format(value)
     Metric.COMPLEXITY -> "%,d".format(value)
     Metric.FILE_COUNT -> "%,d files".format(value)
+    Metric.COMMIT_COUNT -> "%,d commits".format(value)
 }

--- a/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
@@ -3,6 +3,7 @@ package com.github.projectstats
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import java.awt.Color
+import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -10,6 +11,7 @@ import java.awt.Point
 import java.awt.RenderingHints
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.awt.event.MouseMotionAdapter
 import java.awt.geom.Rectangle2D
 import javax.swing.JPanel
 
@@ -31,6 +33,7 @@ class TreemapPanel : JPanel() {
     private var rects: List<Pair<Rectangle2D.Double, StatGroup>> = emptyList()
     private var colorFor: (StatGroup) -> Color = { hashColor(it.key) }
     private var onDrillChanged: ((StatGroup?) -> Unit)? = null
+    private var singleClickDrill: Boolean = false
 
     init {
         background = JBColor.background()
@@ -38,15 +41,32 @@ class TreemapPanel : JPanel() {
         addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
                 val hit = hitTest(e.point) ?: return
-                if (e.clickCount == 2 && hit.children.isNotEmpty()) {
+                val hasChildren = hit.children.isNotEmpty()
+                val drillClick = (singleClickDrill && e.clickCount == 1 && e.button == MouseEvent.BUTTON1)
+                        || e.clickCount == 2
+                if (drillClick && hasChildren) {
                     drillInto(hit)
-                } else if (e.button == MouseEvent.BUTTON3 || (e.clickCount == 2 && hit.children.isEmpty())) {
+                } else if (e.button == MouseEvent.BUTTON3 || (e.clickCount == 2 && !hasChildren)) {
                     // right-click or double-click on a leaf goes back a level
                     popDrill()
                 }
             }
         })
+        addMouseMotionListener(object : MouseMotionAdapter() {
+            override fun mouseMoved(e: MouseEvent) {
+                val hit = hitTest(e.point)
+                val drillable = singleClickDrill && hit != null && hit.children.isNotEmpty()
+                cursor = if (drillable) Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                else Cursor.getDefaultCursor()
+            }
+        })
         toolTipText = "" // enable tooltips
+    }
+
+    /** Enable single-click drill-down (with hand cursor) for drillable cells. */
+    fun setSingleClickDrill(enabled: Boolean) {
+        singleClickDrill = enabled
+        if (!enabled) cursor = Cursor.getDefaultCursor()
     }
 
     fun setData(groups: List<StatGroup>, metric: Metric, colorFn: (StatGroup) -> Color) {
@@ -68,6 +88,20 @@ class TreemapPanel : JPanel() {
 
     fun currentPath(): String =
         if (drillStack.isEmpty()) "" else drillStack.joinToString(" / ") { it.display() }
+
+    /** Number of drill steps currently on the stack. */
+    fun drillDepth(): Int = drillStack.size
+
+    /** Display string of the drill step at [index] (0-based). */
+    fun drillStepDisplay(index: Int): String = drillStack.elementAt(index).display()
+
+    /** Pop drill steps until only [keep] remain (0 = full reset to root). */
+    fun popToDepth(keep: Int) {
+        if (keep < 0 || keep >= drillStack.size) return
+        while (drillStack.size > keep) drillStack.removeLast()
+        repaint()
+        onDrillChanged?.invoke(currentDrilledGroup())
+    }
 
     fun popDrill(): Boolean {
         if (drillStack.isEmpty()) return false
@@ -101,7 +135,9 @@ class TreemapPanel : JPanel() {
     override fun getToolTipText(event: MouseEvent): String? {
         val hit = hitTest(event.point) ?: return null
         val v = hit.value(metric)
-        val suffix = if (hit.children.isNotEmpty()) "  (double-click to drill in)" else ""
+        val suffix = if (hit.children.isNotEmpty()) {
+            if (singleClickDrill) "  (click to drill in)" else "  (double-click to drill in)"
+        } else ""
         return "<html><b>${escape(hit.key)}</b><br/>" +
                 "${metric.display}: ${format(metric, v)}<br/>" +
                 "Files: ${hit.fileCount}, Total LOC: ${hit.totalLines}, Size: ${humanBytes(hit.sizeBytes)}" +
@@ -148,8 +184,8 @@ class TreemapPanel : JPanel() {
             }
         }
 
-        // Breadcrumb
-        if (drillStack.isNotEmpty()) {
+        // In-treemap breadcrumb (double-click modes only — directory mode shows a toolbar breadcrumb).
+        if (drillStack.isNotEmpty() && !singleClickDrill) {
             val crumb = "▲ ${currentPath()}  (right-click or double-click a leaf to go back)"
             g2.color = JBColor.foreground()
             g2.drawString(crumb, 6, height - 6)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
         <b>language</b>, <b>module</b>, <b>source category</b>
         (source/test/resources/generated), or <b>directory tree</b> with a treemap,
         GitHub-style stacked bar, and sortable table. Drill into directories with
-        double-click — empty single-child folder chains collapse automatically.<br/>
+        a single click — empty single-child folder chains collapse automatically.<br/>
         Cyclomatic complexity uses IntelliJ PSI for every language with a PSI tree
         (Java, Kotlin, Groovy, Python, JS/TS, PHP, Go, Ruby, Rust, Scala, Dart, …)
         and falls back to keyword counting for plain-text files.

--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
+  <!-- Left bracket -->
+  <path d="M11 5 H5 V35 H11" stroke="#3574F0" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Right bracket -->
+  <path d="M29 5 H35 V35 H29" stroke="#3574F0" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Sigma Σ -->
+  <path d="M28 11 H13 L20.5 20 L13 29 H28" stroke="#1A1A1A" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40" fill="none">
+  <!-- Left bracket -->
+  <path d="M11 5 H5 V35 H11" stroke="#87A8F5" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Right bracket -->
+  <path d="M29 5 H35 V35 H29" stroke="#87A8F5" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Sigma Σ -->
+  <path d="M28 11 H13 L20.5 20 L13 29 H28" stroke="#E8E8E8" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds a new **Commits** metric that tallies how many HEAD-reachable commits touched each file. Works on the same axes as the existing metrics (language / module / category / directory tree) and drives the treemap, stacked bar, table column, and summary bar.

## Implementation

- **`GitCommitCountCalculator`** — single `git log --pretty=format: --name-only` per discovered git root (walks up from each content root looking for `.git`). Stream-parses stdout, incrementing a per-absolute-path counter. No per-file subprocesses.
- Degrades gracefully: non-git projects, missing `git` on PATH, 120s timeout, and subprocess errors all silently yield zero counts. `core.quotePath=false` ensures Unicode filenames match `VirtualFile` paths.
- Progress is reported and the scan remains cancellable (poll every 16K lines).
- `FileStat` / `StatGroup` / `ScanResult` gain a `commitCount` field; `Metric.COMMIT_COUNT` joins the dropdown; the table gains a **Commits** column; the summary bar shows a drill-scoped commit total.

## Testing

- `./gradlew buildPlugin` — SUCCESS (only pre-existing `baseDir` deprecation warning).
