### PR TITLE
feat(treemap): animate drill-down and add hover preview

### DIFF
--- a/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
@@ -33,8 +33,13 @@ import kotlin.collections.sumOf
 class TreemapPanel : JPanel() {
 
     /** One user-level drill step. A step may represent a chain of single-child folders
-     *  that were auto-traversed when drilling down — treated atomically for Up/pop. */
-    private data class DrillStep(val chain: List<StatGroup>) {
+     *  that were auto-traversed when drilling down — treated atomically for Up/pop.
+     *  [srcRectAtPush] is the parent (clicked) cell's rect at the moment of drill-in,
+     *  used to animate drill-out back into that position. */
+    private data class DrillStep(
+        val chain: List<StatGroup>,
+        val srcRectAtPush: Rectangle2D.Double,
+    ) {
         val target: StatGroup get() = chain.last()
         fun display(): String = chain.joinToString("/") { it.key }
     }
@@ -52,12 +57,31 @@ class TreemapPanel : JPanel() {
     private var layoutW: Double = -1.0
     private var layoutH: Double = -1.0
 
-    // Metric-change animation state.
+    // Animation state. METRIC = cells morph between two metric values; DRILL_IN/OUT = zoom into/out
+    // of a clicked cell. All three reuse the same Swing Timer + eased-t machinery.
+    private enum class AnimKind { METRIC, DRILL_IN, DRILL_OUT }
+    private var animKind: AnimKind = AnimKind.METRIC
     private var animTimer: javax.swing.Timer? = null
-    private var animFromRects: Map<String, Rectangle2D.Double>? = null
     private var animT: Float = 1f
     private var animStartNanos: Long = 0L
     private val animDurationMs = 260
+    private val drillAnimDurationMs = 320
+
+    // METRIC anim state.
+    private var animFromRects: Map<String, Rectangle2D.Double>? = null
+
+    // DRILL anim state.
+    /** Per-child key -> source rect (where the child starts the animation). */
+    private var drillFromRects: Map<String, Rectangle2D.Double>? = null
+    /** Cells from the *outgoing* layout, painted with fading alpha during drill. */
+    private var drillGhostCells: List<Pair<Rectangle2D.Double, StatGroup>> = emptyList()
+    /** Single highlight ghost (the parent cell during drill-in, or the collapsing-target during drill-out). */
+    private var drillGhostFocusRect: Rectangle2D.Double? = null
+    private var drillGhostFocusGroup: StatGroup? = null
+
+    // Hover preview state.
+    private var hoverGroup: StatGroup? = null
+    private var hoverChildRects: List<Pair<Rectangle2D.Double, StatGroup>> = emptyList()
 
     init {
         background = JBColor.background()
@@ -78,15 +102,26 @@ class TreemapPanel : JPanel() {
         })
         addMouseMotionListener(object : MouseMotionAdapter() {
             override fun mouseMoved(e: MouseEvent) {
-                // Avoid calling setCursor() — and the native updateCursorImmediately()
-                // it triggers — unless the cursor actually needs to change.
-                if (!singleClickDrill) return
                 val hit = hitTest(e.point)
-                val newCursor = if (hit != null && hit.children.isNotEmpty())
+                // Cursor — only update when it actually needs to change to avoid native cursor churn.
+                val newCursor = if (singleClickDrill && hit != null && hit.children.isNotEmpty())
                     Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
                 else
                     Cursor.getDefaultCursor()
                 if (cursor !== newCursor) cursor = newCursor
+
+                // Hover preview: lazily lay out children inside a drillable cell. Only repaint when the
+                // hovered group actually changes — squarify is O(n²) so we cache aggressively.
+                updateHoverPreview(hit)
+            }
+
+            override fun mouseDragged(e: MouseEvent) {
+                clearHoverPreview()
+            }
+        })
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseExited(e: MouseEvent) {
+                clearHoverPreview()
             }
         })
         toolTipText = "" // enable tooltips
@@ -120,7 +155,8 @@ class TreemapPanel : JPanel() {
         this.drillStack.clear()
         if (preservedKeys.isNotEmpty()) restoreDrillPath(preservedKeys)
         layoutDirty = true
-        if (animateFrom != null) startAnimation(animateFrom) else stopAnimation()
+        clearHoverPreview()
+        if (animateFrom != null) startMetricAnimation(animateFrom) else stopAnimation()
         repaint()
     }
 
@@ -139,20 +175,57 @@ class TreemapPanel : JPanel() {
                 scan = match.children
             }
             if (chain.size != step.size) break
-            drillStack.addLast(DrillStep(chain))
+            // Replay loses original click-rects; use a zero rect as a sentinel — the user can't
+            // actually animate a drill-out we never animated into.
+            drillStack.addLast(DrillStep(chain, Rectangle2D.Double(0.0, 0.0, 0.0, 0.0)))
             level = chain.last().children
         }
     }
 
 
-    private fun startAnimation(from: Map<String, Rectangle2D.Double>) {
+    private fun startMetricAnimation(from: Map<String, Rectangle2D.Double>) {
         stopAnimation()
+        animKind = AnimKind.METRIC
         animFromRects = from
+        startTimer(animDurationMs)
+    }
+
+    private fun startDrillInAnimation(
+        fromRects: Map<String, Rectangle2D.Double>,
+        ghostCells: List<Pair<Rectangle2D.Double, StatGroup>>,
+        ghostFocusRect: Rectangle2D.Double,
+        ghostFocusGroup: StatGroup,
+    ) {
+        stopAnimation()
+        animKind = AnimKind.DRILL_IN
+        drillFromRects = fromRects
+        drillGhostCells = ghostCells
+        drillGhostFocusRect = ghostFocusRect
+        drillGhostFocusGroup = ghostFocusGroup
+        startTimer(drillAnimDurationMs)
+    }
+
+    private fun startDrillOutAnimation(
+        fromRects: Map<String, Rectangle2D.Double>,
+        ghostCells: List<Pair<Rectangle2D.Double, StatGroup>>,
+        collapseTargetRect: Rectangle2D.Double,
+        collapseTargetGroup: StatGroup,
+    ) {
+        stopAnimation()
+        animKind = AnimKind.DRILL_OUT
+        drillFromRects = fromRects
+        drillGhostCells = ghostCells
+        drillGhostFocusRect = collapseTargetRect
+        drillGhostFocusGroup = collapseTargetGroup
+        startTimer(drillAnimDurationMs)
+    }
+
+    private fun startTimer(durationMs: Int) {
         animT = 0f
         animStartNanos = System.nanoTime()
         val timer = javax.swing.Timer(16) {
             val elapsedMs = (System.nanoTime() - animStartNanos) / 1_000_000.0
-            animT = (elapsedMs / animDurationMs).toFloat().coerceIn(0f, 1f)
+            animT = (elapsedMs / durationMs).toFloat().coerceIn(0f, 1f)
             repaint()
             if (animT >= 1f) stopAnimation()
         }
@@ -165,6 +238,10 @@ class TreemapPanel : JPanel() {
         animTimer?.stop()
         animTimer = null
         animFromRects = null
+        drillFromRects = null
+        drillGhostCells = emptyList()
+        drillGhostFocusRect = null
+        drillGhostFocusGroup = null
         animT = 1f
     }
 
@@ -194,24 +271,29 @@ class TreemapPanel : JPanel() {
     /** Pop drill steps until only [keep] remain (0 = full reset to root). */
     fun popToDepth(keep: Int) {
         if (keep < 0 || keep >= drillStack.size) return
+        // Capture the rect of the drill step we'll collapse INTO. The first step we pop is the one
+        // whose chain[0] becomes a regular cell at depth `keep` after popping.
+        val firstPopped = drillStack.elementAt(keep)
+        // Snapshot the children currently being shown — they'll fade out as they collapse.
+        val oldRects = rects.toList()
         while (drillStack.size > keep) drillStack.removeLast()
-        stopAnimation()
-        layoutDirty = true
-        repaint()
+        animateDrillOut(firstPopped, oldRects)
         onDrillChanged?.invoke(currentDrilledGroup())
     }
 
     fun popDrill(): Boolean {
         if (drillStack.isEmpty()) return false
-        drillStack.removeLast()
-        stopAnimation()
-        layoutDirty = true
-        repaint()
+        val popped = drillStack.removeLast()
+        val oldRects = rects.toList()
+        animateDrillOut(popped, oldRects)
         onDrillChanged?.invoke(currentDrilledGroup())
         return true
     }
 
     private fun drillInto(hit: StatGroup) {
+        val hitRect = rects.firstOrNull { it.second === hit }?.first
+        // Snapshot the outgoing layout so we can fade it out under the expanding children.
+        val oldRects = rects.toList()
         // Auto-traverse single-child folder chains (e.g. src/main/java/com/example/...) so the
         // user lands directly on the first node with real branching.
         val chain = ArrayList<StatGroup>()
@@ -221,11 +303,82 @@ class TreemapPanel : JPanel() {
             current = current.children[0]
             chain.add(current)
         }
-        drillStack.addLast(DrillStep(chain))
-        stopAnimation()
-        layoutDirty = true
-        repaint()
+        val srcRect = hitRect?.let { Rectangle2D.Double(it.x, it.y, it.width, it.height) }
+            ?: Rectangle2D.Double(0.0, 0.0, width.toDouble(), height.toDouble())
+        drillStack.addLast(DrillStep(chain, srcRect))
+        clearHoverPreview()
+        animateDrillIn(srcRect, hit, oldRects)
         onDrillChanged?.invoke(current)
+    }
+
+    /** Build the new full-panel layout for the current drill level and start a drill-in animation
+     *  that interpolates each child from its srcRect-scoped layout to its full-panel layout. */
+    private fun animateDrillIn(
+        srcRect: Rectangle2D.Double,
+        ghostFocusGroup: StatGroup,
+        oldRects: List<Pair<Rectangle2D.Double, StatGroup>>,
+    ) {
+        val w = width.toDouble()
+        val h = height.toDouble()
+        val data = currentGroups().filter { it.value(metric) > 0 }.sortedByDescending { it.value(metric) }
+        // Always recompute layout for the new level.
+        layoutDirty = true
+        if (data.isEmpty() || w <= 2 || h <= 2 || srcRect.width < 2 || srcRect.height < 2) {
+            stopAnimation()
+            repaint()
+            return
+        }
+        val total = data.sumOf { it.value(metric).toDouble() }
+        val targetRects = ArrayList<Pair<Rectangle2D.Double, StatGroup>>(data.size)
+        squarify(data, total, Rectangle2D.Double(0.0, 0.0, w, h), targetRects)
+        rects = targetRects
+        layoutW = w
+        layoutH = h
+        layoutDirty = false
+
+        val sourceRects = ArrayList<Pair<Rectangle2D.Double, StatGroup>>(data.size)
+        squarify(data, total, srcRect, sourceRects)
+        val fromMap = HashMap<String, Rectangle2D.Double>(sourceRects.size)
+        for ((r, g) in sourceRects) fromMap[g.key] = r
+
+        // Filter ghost cells to omit the parent itself (we render it as the focus ghost beneath the
+        // expanding children) and any cell that would draw on top of where the children appear.
+        val ghosts = oldRects.filter { it.second.key != ghostFocusGroup.key }
+        startDrillInAnimation(fromMap, ghosts, srcRect, ghostFocusGroup)
+    }
+
+    /** Build the new full-panel layout (one level shallower) and start a drill-out animation that
+     *  collapses the previously-shown children into the parent's NEW position in the new layout. */
+    private fun animateDrillOut(popped: DrillStep, oldChildren: List<Pair<Rectangle2D.Double, StatGroup>>) {
+        val w = width.toDouble()
+        val h = height.toDouble()
+        val data = currentGroups().filter { it.value(metric) > 0 }.sortedByDescending { it.value(metric) }
+        layoutDirty = true
+        if (data.isEmpty() || w <= 2 || h <= 2 || oldChildren.isEmpty()) {
+            stopAnimation()
+            repaint()
+            return
+        }
+        val total = data.sumOf { it.value(metric).toDouble() }
+        val targetRects = ArrayList<Pair<Rectangle2D.Double, StatGroup>>(data.size)
+        squarify(data, total, Rectangle2D.Double(0.0, 0.0, w, h), targetRects)
+        rects = targetRects
+        layoutW = w
+        layoutH = h
+        layoutDirty = false
+
+        // Where does the parent (chain[0]) live in the NEW layout? That's the collapse target.
+        val parentKey = popped.chain.first().key
+        val collapseTargetRect = targetRects.firstOrNull { it.second.key == parentKey }?.first
+            ?: popped.srcRectAtPush
+        val collapseTargetGroup = targetRects.firstOrNull { it.second.key == parentKey }?.second
+            ?: popped.chain.first()
+
+        // The "ghost" cells are the children we were just looking at. They start at their old
+        // full-panel positions and shrink toward the parent's new rect.
+        val fromMap = HashMap<String, Rectangle2D.Double>(oldChildren.size)
+        for ((r, g) in oldChildren) fromMap[g.key] = r
+        startDrillOutAnimation(fromMap, oldChildren, collapseTargetRect, collapseTargetGroup)
     }
 
     private fun currentGroups(): List<StatGroup> =
@@ -272,17 +425,23 @@ class TreemapPanel : JPanel() {
         }
 
         val animating = animTimer != null && animT < 1f
-        val fromMap = if (animating) animFromRects else null
         val t = if (animating) easedT() else 1.0
-        for ((rect, grp) in rects) {
-            val displayRect = interpolateRect(fromMap?.get(grp.key), rect, t)
-            val color = colorFor(grp)
-            g2.color = color
-            g2.fill(displayRect)
-            g2.color = JBColor.border()
-            g2.draw(displayRect)
-            drawCellLabel(g2, displayRect, grp, color)
+
+        when {
+            animating && animKind == AnimKind.DRILL_IN -> paintDrillIn(g2, t)
+            animating && animKind == AnimKind.DRILL_OUT -> paintDrillOut(g2, t)
+            else -> {
+                // METRIC anim or no anim. Each cell tweens between its old and new position.
+                val fromMap = if (animating && animKind == AnimKind.METRIC) animFromRects else null
+                for ((rect, grp) in rects) {
+                    val displayRect = interpolateRect(fromMap?.get(grp.key), rect, t)
+                    paintCell(g2, displayRect, grp, fillAlpha = 1f, drawLabel = true)
+                }
+            }
         }
+
+        // Hover preview — only when not in the middle of an animation.
+        if (!animating) paintHoverPreview(g2)
 
         // In-treemap breadcrumb (double-click modes only — directory mode shows a toolbar breadcrumb).
         if (drillStack.isNotEmpty() && !singleClickDrill) {
@@ -290,6 +449,129 @@ class TreemapPanel : JPanel() {
             g2.color = JBColor.foreground()
             g2.drawString(crumb, 6, height - 6)
         }
+    }
+
+    private fun paintDrillIn(g2: Graphics2D, t: Double) {
+        // Outgoing layer: parent + siblings fade out at their old positions.
+        val ghostAlpha = (1.0 - t).toFloat().coerceIn(0f, 1f)
+        if (ghostAlpha > 0.01f) {
+            for ((rect, grp) in drillGhostCells) {
+                paintCell(g2, rect, grp, fillAlpha = ghostAlpha, drawLabel = false)
+            }
+            // Focus parent — painted under children with stronger alpha so children look like
+            // they're emerging from inside it.
+            val focusRect = drillGhostFocusRect
+            val focusGroup = drillGhostFocusGroup
+            if (focusRect != null && focusGroup != null) {
+                paintCell(g2, focusRect, focusGroup, fillAlpha = ghostAlpha, drawLabel = false)
+            }
+        }
+        // Incoming layer: children expand from src→target.
+        val from = drillFromRects
+        val childAlpha = (0.3f + 0.7f * t.toFloat()).coerceIn(0f, 1f)
+        for ((rect, grp) in rects) {
+            val displayRect = interpolateRect(from?.get(grp.key), rect, t)
+            paintCell(g2, displayRect, grp, fillAlpha = childAlpha, drawLabel = t > 0.5)
+        }
+    }
+
+    private fun paintDrillOut(g2: Graphics2D, t: Double) {
+        // Incoming layer: new (shallower) layout fades in.
+        val incomingAlpha = t.toFloat().coerceIn(0f, 1f)
+        for ((rect, grp) in rects) {
+            paintCell(g2, rect, grp, fillAlpha = incomingAlpha, drawLabel = t > 0.6)
+        }
+        // Outgoing layer: previously-shown children shrink toward the collapse target rect.
+        val from = drillFromRects ?: return
+        val target = drillGhostFocusRect ?: return
+        val ghostAlpha = (1.0 - t).toFloat().coerceIn(0f, 1f)
+        if (ghostAlpha < 0.01f) return
+        for ((_, grp) in drillGhostCells) {
+            val src = from[grp.key] ?: continue
+            val displayRect = interpolateRect(src, target, t)
+            paintCell(g2, displayRect, grp, fillAlpha = ghostAlpha, drawLabel = false)
+        }
+    }
+
+    private fun paintCell(
+        g2: Graphics2D,
+        rect: Rectangle2D.Double,
+        grp: StatGroup,
+        fillAlpha: Float,
+        drawLabel: Boolean,
+    ) {
+        if (rect.width < 0.5 || rect.height < 0.5) return
+        val color = colorFor(grp)
+        val prev = g2.composite
+        if (fillAlpha < 0.999f) {
+            g2.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, fillAlpha)
+        }
+        g2.color = color
+        g2.fill(rect)
+        g2.color = JBColor.border()
+        g2.draw(rect)
+        if (drawLabel) drawCellLabel(g2, rect, grp, color)
+        g2.composite = prev
+    }
+
+    /** Render a hover preview by painting the hovered cell's children scaled to fit inside it. */
+    private fun paintHoverPreview(g2: Graphics2D) {
+        if (hoverChildRects.isEmpty()) return
+        val prev = g2.composite
+        g2.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.55f)
+        for ((rect, grp) in hoverChildRects) {
+            if (rect.width < 1 || rect.height < 1) continue
+            g2.color = colorFor(grp)
+            g2.fill(rect)
+            g2.color = JBColor.border()
+            g2.draw(rect)
+        }
+        g2.composite = prev
+    }
+
+    private fun updateHoverPreview(hit: StatGroup?) {
+        // Don't show previews while an animation is running — too visually noisy.
+        if (animTimer != null && animT < 1f) {
+            clearHoverPreview()
+            return
+        }
+        if (hit == null || hit.children.size < 3) {
+            clearHoverPreview()
+            return
+        }
+        if (hit === hoverGroup) return
+        val rect = rects.firstOrNull { it.second === hit }?.first ?: run {
+            clearHoverPreview(); return
+        }
+        // Need enough space for the preview to be readable.
+        if (rect.width < 80 || rect.height < 60) {
+            clearHoverPreview()
+            return
+        }
+        // Reserve space for the parent's own label inside the cell.
+        val padTop = 18.0
+        val pad = 4.0
+        val inner = Rectangle2D.Double(
+            rect.x + pad, rect.y + padTop,
+            (rect.width - 2 * pad).coerceAtLeast(0.0),
+            (rect.height - padTop - pad).coerceAtLeast(0.0),
+        )
+        val data = hit.children.filter { it.value(metric) > 0 }.sortedByDescending { it.value(metric) }
+        val total = data.sumOf { it.value(metric).toDouble() }
+        val out = ArrayList<Pair<Rectangle2D.Double, StatGroup>>(data.size)
+        if (total > 0 && inner.width > 4 && inner.height > 4) {
+            squarify(data, total, inner, out)
+        }
+        hoverGroup = hit
+        hoverChildRects = out
+        repaint()
+    }
+
+    private fun clearHoverPreview() {
+        if (hoverGroup == null && hoverChildRects.isEmpty()) return
+        hoverGroup = null
+        hoverChildRects = emptyList()
+        repaint()
     }
 
     private fun interpolateRect(from: Rectangle2D.Double?, to: Rectangle2D.Double, t: Double): Rectangle2D.Double {


### PR DESCRIPTION
## Drill-down animation
Clicking a treemap cell now animates its children expanding from inside the clicked rect to fill the panel; popping reverses the animation.

- Each `DrillStep` records the clicked source rect (`srcRectAtPush`).
- **DRILL_IN**: parent + siblings ghost-fade at old positions while children interpolate from a squarify-into-srcRect layout → squarify-into-fullpanel layout, fading in.
- **DRILL_OUT**: new (shallower) layout fades in while popped children shrink toward the parent's rect in the new layout.
- Single-child folder-chain auto-traversal still collapses to one `DrillStep`.
- All animations share one Swing Timer + an `AnimKind` discriminator (`METRIC` / `DRILL_IN` / `DRILL_OUT`).

## Hover preview
Hovering over a sufficiently large group cell shows a translucent squarified mini-layout of its children inside the cell.

- Gated on cell size ≥ 80×60 and ≥ 3 children.
- Cached by hovered-group identity (squarify is O(n²)).
- Cleared on drag, drill, animation start, mouse exit, or `setData`.

## Validation
- `./gradlew compileKotlin` ✅
- `./gradlew test` ✅