### PR TITLE
feat(coverage): language-agnostic test coverage metric

### DIFF
--- a/src/main/kotlin/com/github/projectstats/Model.kt
+++ b/src/main/kotlin/com/github/projectstats/Model.kt
@@ -28,6 +28,10 @@ data class FileStat(
     val sizeBytes: Long,
     val commitCount: Int = 0,
     val fileCount: Int = 1,
+    /** Number of executable/instrumentable lines reported as covered. */
+    val coveredLines: Int = 0,
+    /** Number of executable/instrumentable lines in the file (covered + uncovered). 0 = no coverage data. */
+    val coverableLines: Int = 0,
 )
 
 /**
@@ -43,6 +47,8 @@ data class StatGroup(
     val fileCount: Long,
     val commitCount: Long,
     val children: List<StatGroup> = emptyList(),
+    val coveredLines: Long = 0,
+    val coverableLines: Long = 0,
 ) {
     fun value(metric: Metric): Long = when (metric) {
         Metric.LOC -> totalLines
@@ -52,6 +58,14 @@ data class StatGroup(
         Metric.SIZE -> sizeBytes
         Metric.FILE_COUNT -> fileCount
         Metric.COMMIT_COUNT -> commitCount
+        Metric.COVERED_LOC -> coveredLines
+        Metric.UNCOVERED_LOC -> (coverableLines - coveredLines).coerceAtLeast(0)
+    }
+
+    /** Coverage as a fraction in [0, 1], or null if the group has no coverage data. */
+    fun coverageFraction(): Double? {
+        if (coverableLines <= 0) return null
+        return coveredLines.toDouble() / coverableLines.toDouble()
     }
 }
 
@@ -62,7 +76,9 @@ enum class Metric(val display: String) {
     COMPLEXITY("Complexity"),
     SIZE("File size"),
     FILE_COUNT("File count"),
-    COMMIT_COUNT("Commits");
+    COMMIT_COUNT("Commits"),
+    COVERED_LOC("Covered LOC"),
+    UNCOVERED_LOC("Uncovered LOC");
 
     override fun toString() = display
 }
@@ -89,4 +105,8 @@ data class ScanResult(
     val fileCount: Long,
     val commitCount: Long,
     val scannedMillis: Long,
+    val coveredLines: Long = 0,
+    val coverableLines: Long = 0,
+    /** Description of where coverage data came from (e.g. "lcov.info"), or null if none was loaded. */
+    val coverageSource: String? = null,
 )

--- a/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectScanner.kt
@@ -1,6 +1,9 @@
 package com.github.projectstats
 
-import com.intellij.openapi.application.ReadAction
+import com.github.projectstats.coverage.CoverageData
+import com.github.projectstats.coverage.CoverageLoader
+import com.github.projectstats.coverage.CoverageMatcher
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
@@ -44,7 +47,11 @@ object ProjectScanner {
         if (projectBase != null) roots.add(projectBase)
 
         val toProcess = collectFiles(roots, indicator)
-        val files = classifyInParallel(toProcess, project, fileIndex, projectBase, commitCounts, indicator)
+        val rawFiles = classifyInParallel(toProcess, project, fileIndex, projectBase, commitCounts, indicator)
+
+        // Coverage is opt-in: we only attach it if a recognised report exists at a standard path.
+        val coverage: CoverageData? = projectBase?.let { CoverageLoader.load(it, indicator) }
+        val files = applyCoverage(rawFiles, coverage)
 
         var totalLines = 0L
         var nonBlank = 0L
@@ -52,6 +59,8 @@ object ProjectScanner {
         var complexityTotal = 0L
         var size = 0L
         var commitsTotal = 0L
+        var coveredTotal = 0L
+        var coverableTotal = 0L
         for (stat in files) {
             totalLines += stat.totalLines
             nonBlank += stat.nonBlankLines
@@ -59,6 +68,8 @@ object ProjectScanner {
             complexityTotal += stat.complexity
             size += stat.sizeBytes
             commitsTotal += stat.commitCount
+            coveredTotal += stat.coveredLines
+            coverableTotal += stat.coverableLines
         }
 
         return ScanResult(
@@ -71,7 +82,19 @@ object ProjectScanner {
             fileCount = files.size.toLong(),
             commitCount = commitsTotal,
             scannedMillis = System.currentTimeMillis() - started,
+            coveredLines = coveredTotal,
+            coverableLines = coverableTotal,
+            coverageSource = coverage?.let { "${it.format.display}: ${it.sourceLabel}" },
         )
+    }
+
+    private fun applyCoverage(files: List<FileStat>, coverage: CoverageData?): List<FileStat> {
+        if (coverage == null || coverage.perFile.isEmpty()) return files
+        val matcher = CoverageMatcher(coverage)
+        return files.map { f ->
+            val match = matcher.match(f.relativePath) ?: return@map f
+            f.copy(coveredLines = match.coveredLines, coverableLines = match.coverableLines)
+        }
     }
 
     /** Phase 1: walk VFS (fast, sequential) to collect candidate files, skipping known build/VCS dirs. */
@@ -110,7 +133,7 @@ object ProjectScanner {
         try {
             val futures = toProcess.map { file ->
                 executor.submit(Callable {
-                    ReadAction.compute<FileStat?, RuntimeException> {
+                    runReadAction {
                         classify(file, project, fileIndex, projectBase)
                     }?.let { base ->
                         if (commitCounts.isEmpty()) base

--- a/src/main/kotlin/com/github/projectstats/ProjectStatsPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/ProjectStatsPanel.kt
@@ -267,7 +267,7 @@ class ProjectStatsPanel(private val project: Project) : JPanel(BorderLayout()) {
                 ApplicationManager.getApplication().invokeLater {
                     scanResult = result
                     setScanning(false)
-                    footerStatus.text = " "
+                    footerStatus.text = result.coverageSource?.let { "Coverage: $it" } ?: " "
                     refreshViews()
                 }
             }

--- a/src/main/kotlin/com/github/projectstats/StatsAggregator.kt
+++ b/src/main/kotlin/com/github/projectstats/StatsAggregator.kt
@@ -41,6 +41,8 @@ object StatsAggregator {
         var size: Long = 0,
         var count: Long = 0,
         var commits: Long = 0,
+        var covered: Long = 0,
+        var coverable: Long = 0,
     )
 
     private inline fun flatGroup(files: List<FileStat>, keyOf: (FileStat) -> String): List<StatGroup> {
@@ -54,9 +56,12 @@ object StatsAggregator {
             acc.size += f.sizeBytes
             acc.count += 1
             acc.commits += f.commitCount
+            acc.covered += f.coveredLines
+            acc.coverable += f.coverableLines
         }
         return byKey.entries.map { (k, v) ->
-            StatGroup(k, v.total, v.nonBlank, v.code, v.complexity, v.size, v.count, v.commits)
+            StatGroup(k, v.total, v.nonBlank, v.code, v.complexity, v.size, v.count, v.commits,
+                emptyList(), v.covered, v.coverable)
         }.sortedByDescending { it.totalLines }
     }
 
@@ -75,6 +80,8 @@ object StatsAggregator {
             var size: Long = 0,
             var count: Long = 0,
             var commits: Long = 0,
+            var covered: Long = 0,
+            var coverable: Long = 0,
             var isFile: Boolean = false,
         )
 
@@ -87,6 +94,7 @@ object StatsAggregator {
             root.code += f.codeLines; root.complexity += f.complexity
             root.size += f.sizeBytes; root.count += 1
             root.commits += f.commitCount
+            root.covered += f.coveredLines; root.coverable += f.coverableLines
             for ((idx, part) in parts.withIndex()) {
                 node = node.children.getOrPut(part) { Node(part) }
                 node.total += f.totalLines
@@ -96,13 +104,16 @@ object StatsAggregator {
                 node.size += f.sizeBytes
                 node.count += 1
                 node.commits += f.commitCount
+                node.covered += f.coveredLines
+                node.coverable += f.coverableLines
                 if (idx == parts.lastIndex) node.isFile = true
             }
         }
 
         fun convert(n: Node): StatGroup {
             val kids = n.children.values.map { convert(it) }.sortedByDescending { it.totalLines }
-            return StatGroup(n.name, n.total, n.nonBlank, n.code, n.complexity, n.size, n.count, n.commits, kids)
+            return StatGroup(n.name, n.total, n.nonBlank, n.code, n.complexity, n.size, n.count, n.commits,
+                kids, n.covered, n.coverable)
         }
         // Return the top-level children (under <project>); treemap presents them as roots.
         return convert(root).children

--- a/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
+++ b/src/main/kotlin/com/github/projectstats/TreemapPanel.kt
@@ -443,7 +443,8 @@ fun humanBytes(b: Long): String {
 
 fun format(metric: Metric, value: Long): String = when (metric) {
     Metric.SIZE -> humanBytes(value)
-    Metric.LOC, Metric.NON_BLANK_LOC, Metric.CODE_LOC -> "%,d lines".format(value)
+    Metric.LOC, Metric.NON_BLANK_LOC, Metric.CODE_LOC,
+    Metric.COVERED_LOC, Metric.UNCOVERED_LOC -> "%,d lines".format(value)
     Metric.COMPLEXITY -> "%,d".format(value)
     Metric.FILE_COUNT -> "%,d files".format(value)
     Metric.COMMIT_COUNT -> "%,d commits".format(value)

--- a/src/main/kotlin/com/github/projectstats/coverage/CoberturaReader.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/CoberturaReader.kt
@@ -1,0 +1,65 @@
+package com.github.projectstats.coverage
+
+import javax.xml.parsers.SAXParserFactory
+import org.xml.sax.Attributes
+import org.xml.sax.helpers.DefaultHandler
+
+/**
+ * Cobertura XML parser.
+ *
+ * Cobertura is the format produced by `coverage.py` (Python), .NET (`coverlet`), PHPUnit,
+ * Karma's cobertura reporter, and many JVM Gradle/Maven coverage plugins.
+ *
+ * Schema (relevant parts):
+ * ```
+ * <coverage>
+ *   <packages>
+ *     <package name="...">
+ *       <classes>
+ *         <class filename="src/foo/bar.py">
+ *           <lines>
+ *             <line number="12" hits="3"/>
+ *             <line number="13" hits="0"/>
+ * ```
+ */
+object CoberturaReader : CoverageReader {
+    override val format: CoverageFormat = CoverageFormat.COBERTURA
+
+    override fun parse(text: String, sourceLabel: String): CoverageData? {
+        if ("<coverage" !in text || "<class" !in text) return null
+        val perFile = HashMap<String, IntArray>() // [covered, coverable]
+        val factory = SAXParserFactory.newInstance().apply {
+            // Disable external entity resolution (XXE protection).
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            isNamespaceAware = false
+        }
+        val parser = factory.newSAXParser()
+        var currentFile: String? = null
+        try {
+            parser.parse(text.byteInputStream(), object : DefaultHandler() {
+                override fun startElement(uri: String?, localName: String?, qName: String, attrs: Attributes) {
+                    when (qName) {
+                        "class" -> {
+                            currentFile = attrs.getValue("filename")?.takeIf { it.isNotBlank() }
+                        }
+                        "line" -> {
+                            val f = currentFile ?: return
+                            val hits = attrs.getValue("hits")?.toIntOrNull() ?: return
+                            val arr = perFile.getOrPut(f) { IntArray(2) }
+                            arr[1]++
+                            if (hits > 0) arr[0]++
+                        }
+                    }
+                }
+
+                override fun endElement(uri: String?, localName: String?, qName: String) {
+                    if (qName == "class") currentFile = null
+                }
+            })
+        } catch (_: Exception) {
+            return null
+        }
+        if (perFile.isEmpty()) return null
+        return CoverageData(format, sourceLabel, perFile.mapValues { (_, v) -> FileCoverage(v[0], v[1]) })
+    }
+}

--- a/src/main/kotlin/com/github/projectstats/coverage/CoverageData.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/CoverageData.kt
@@ -1,0 +1,28 @@
+package com.github.projectstats.coverage
+
+/**
+ * Per-file coverage record. Counts are in *instrumentable* (executable) lines, not source lines.
+ */
+data class FileCoverage(val coveredLines: Int, val coverableLines: Int)
+
+/**
+ * Format produced by some test runner / coverage tool. We support the formats with the broadest
+ * cross-language reach.
+ */
+enum class CoverageFormat(val display: String) {
+    LCOV("LCOV"),
+    COBERTURA("Cobertura XML"),
+    JACOCO("JaCoCo XML"),
+}
+
+/**
+ * Coverage data keyed by file path.
+ *
+ * Path keys may be absolute paths, project-relative paths, or partial suffix paths — the actual
+ * matching against [com.github.projectstats.FileStat.relativePath] is done by [CoverageMatcher].
+ */
+data class CoverageData(
+    val format: CoverageFormat,
+    val sourceLabel: String,
+    val perFile: Map<String, FileCoverage>,
+)

--- a/src/main/kotlin/com/github/projectstats/coverage/CoverageLoader.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/CoverageLoader.kt
@@ -1,0 +1,89 @@
+package com.github.projectstats.coverage
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
+
+/**
+ * Auto-discovery + parsing for coverage reports anywhere under the project base.
+ *
+ * Discovery rules (first match wins, in this order):
+ *  1. **LCOV** — `lcov.info`, `coverage/lcov.info`, `coverage.lcov`
+ *  2. **Cobertura XML** — `coverage.xml`, `cobertura-coverage.xml`, `coverage/cobertura-coverage.xml`
+ *  3. **JaCoCo XML** — anywhere under `build/reports/jacoco/` or `target/site/jacoco/jacoco.xml`
+ *
+ * If multiple JaCoCo reports exist (per-module aggregation), they are merged.
+ *
+ * Paths under `node_modules`, `.git`, and other build/VCS dirs are skipped to keep the walk fast.
+ */
+object CoverageLoader {
+
+    private val LOG = logger<CoverageLoader>()
+
+    private val LCOV_NAMES = setOf("lcov.info", "coverage.lcov")
+    private val COBERTURA_NAMES = setOf("cobertura-coverage.xml", "coverage.xml")
+    private val SKIPPED_DIRS = setOf(".git", ".hg", ".idea", "node_modules", ".gradle", "dist")
+
+    /**
+     * Scan [projectBase] for a coverage report. Returns merged coverage data, or null if nothing is found.
+     */
+    fun load(projectBase: VirtualFile, indicator: ProgressIndicator?): CoverageData? {
+        indicator?.text2 = "Looking for coverage reports"
+        val lcov = ArrayList<VirtualFile>(2)
+        val cobertura = ArrayList<VirtualFile>(2)
+        val jacoco = ArrayList<VirtualFile>(8)
+
+        VfsUtilCore.visitChildrenRecursively(projectBase, object : VirtualFileVisitor<Any?>() {
+            override fun visitFile(file: VirtualFile): Boolean {
+                if (file.isDirectory) {
+                    return file.name !in SKIPPED_DIRS
+                }
+                val name = file.name
+                val nameLower = name.lowercase()
+                when {
+                    nameLower in LCOV_NAMES -> lcov.add(file)
+                    nameLower in COBERTURA_NAMES -> cobertura.add(file)
+                    nameLower.startsWith("jacoco") && nameLower.endsWith(".xml") -> jacoco.add(file)
+                }
+                return true
+            }
+        })
+
+        // LCOV first (broadest coverage of languages), then Cobertura, then JaCoCo.
+        lcov.firstOrNull()?.let { return readSafely(it, LcovReader) }
+        cobertura.firstOrNull()?.let { return readSafely(it, CoberturaReader) }
+        if (jacoco.isNotEmpty()) {
+            return readJacocoMerged(jacoco)
+        }
+        return null
+    }
+
+    private fun readSafely(file: VirtualFile, reader: CoverageReader): CoverageData? {
+        return try {
+            val text = String(file.contentsToByteArray(), file.charset)
+            reader.parse(text, file.name)
+        } catch (e: Exception) {
+            LOG.warn("Failed to read ${reader.format} report at ${file.path}: ${e.message}")
+            null
+        }
+    }
+
+    private fun readJacocoMerged(files: List<VirtualFile>): CoverageData? {
+        val merged = HashMap<String, FileCoverage>()
+        var anyOk = false
+        for (f in files) {
+            val data = readSafely(f, JacocoReader) ?: continue
+            anyOk = true
+            for ((path, cov) in data.perFile) {
+                val prev = merged[path]
+                merged[path] = if (prev == null) cov
+                else FileCoverage(prev.coveredLines + cov.coveredLines, prev.coverableLines + cov.coverableLines)
+            }
+        }
+        if (!anyOk || merged.isEmpty()) return null
+        val label = if (files.size == 1) files[0].name else "${files.size} JaCoCo reports"
+        return CoverageData(CoverageFormat.JACOCO, label, merged)
+    }
+}

--- a/src/main/kotlin/com/github/projectstats/coverage/CoverageMatcher.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/CoverageMatcher.kt
@@ -1,0 +1,56 @@
+package com.github.projectstats.coverage
+
+/**
+ * Resolves coverage entries to project files.
+ *
+ * Coverage tools are inconsistent about the path format they emit:
+ *  - LCOV may use absolute paths, paths relative to the test runner CWD, or just bare filenames.
+ *  - Cobertura uses paths relative to a `<source>` root configured at report-generation time.
+ *  - JaCoCo uses `package/sourcefile` (e.g. `com/example/Foo.kt`), with no source-root prefix.
+ *
+ * Strategy: index coverage entries by all their path suffixes; for each project file, look up
+ * the longest suffix that matches. This is O(N + M) preprocessing + O(depth) per lookup, and
+ * tolerates all three path styles above.
+ */
+class CoverageMatcher(private val data: CoverageData) {
+
+    /** suffix -> covered/coverable, where suffix is "tail/of/path". Stored normalised with '/'. */
+    private val suffixIndex: Map<String, FileCoverage>
+
+    init {
+        // For each coverage entry path, register all its suffixes (full path, last 2 segments, …, last 1).
+        // When two coverage entries share a suffix, we keep the one with more coverable lines (larger /
+        // more authoritative), which protects against tiny duplicate <class> entries that some tools emit.
+        val acc = HashMap<String, FileCoverage>(data.perFile.size * 2)
+        for ((rawPath, cov) in data.perFile) {
+            val parts = rawPath.replace('\\', '/').trim('/').split('/').filter { it.isNotEmpty() }
+            if (parts.isEmpty()) continue
+            for (i in parts.indices) {
+                val suffix = parts.subList(i, parts.size).joinToString("/")
+                val prev = acc[suffix]
+                if (prev == null || cov.coverableLines > prev.coverableLines) {
+                    acc[suffix] = cov
+                }
+            }
+        }
+        suffixIndex = acc
+    }
+
+    /**
+     * Look up coverage for [relativePath]. Returns null if no entry matches.
+     *
+     * Tries the full normalised path first (cheapest), then progressively shorter suffixes. This
+     * yields the *longest* matching suffix, which minimises false positives on common filenames
+     * like `index.js` or `__init__.py`.
+     */
+    fun match(relativePath: String): FileCoverage? {
+        val parts = relativePath.replace('\\', '/').trim('/').split('/').filter { it.isNotEmpty() }
+        if (parts.isEmpty()) return null
+        for (i in parts.indices) {
+            val suffix = parts.subList(i, parts.size).joinToString("/")
+            val hit = suffixIndex[suffix]
+            if (hit != null) return hit
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/com/github/projectstats/coverage/CoverageReader.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/CoverageReader.kt
@@ -1,0 +1,12 @@
+package com.github.projectstats.coverage
+
+/**
+ * Parses a coverage report into [CoverageData]. Implementations are stateless and side-effect free
+ * so they can be unit-tested without a [com.intellij.openapi.vfs.VirtualFile].
+ */
+interface CoverageReader {
+    val format: CoverageFormat
+
+    /** Parse the report's textual content. Returns null if the input is unrecognisable for this format. */
+    fun parse(text: String, sourceLabel: String): CoverageData?
+}

--- a/src/main/kotlin/com/github/projectstats/coverage/JacocoReader.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/JacocoReader.kt
@@ -1,0 +1,81 @@
+package com.github.projectstats.coverage
+
+import javax.xml.parsers.SAXParserFactory
+import org.xml.sax.Attributes
+import org.xml.sax.helpers.DefaultHandler
+
+/**
+ * JaCoCo XML report parser.
+ *
+ * JaCoCo is the de-facto standard for JVM coverage. It produces line-level data per source file.
+ * Files are reported by package name + sourcefilename — caller resolves them against source roots.
+ *
+ * Schema (relevant parts):
+ * ```
+ * <report>
+ *   <package name="com/example/foo">
+ *     <sourcefile name="MyClass.kt">
+ *       <line nr="12" mi="0" ci="3"/>   <!-- mi = missed instructions, ci = covered instructions -->
+ *       <counter type="LINE" missed="2" covered="8"/>
+ * ```
+ *
+ * We use the `LINE` counter on each `sourcefile` for accurate covered/missed line counts (more
+ * reliable than counting `<line>` elements, which use instruction granularity).
+ *
+ * Path keys are emitted as `package/sourcefile` (e.g. `com/example/foo/MyClass.kt`) so they can
+ * be matched suffix-wise against `FileStat.relativePath`.
+ */
+object JacocoReader : CoverageReader {
+    override val format: CoverageFormat = CoverageFormat.JACOCO
+
+    override fun parse(text: String, sourceLabel: String): CoverageData? {
+        if ("<report" !in text || "<sourcefile" !in text) return null
+        val perFile = HashMap<String, FileCoverage>()
+        val factory = SAXParserFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            // JaCoCo XML uses a DOCTYPE in older versions — accept it but disable external entities.
+            try {
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+                setFeature("http://xml.org/sax/features/external-general-entities", false)
+                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            } catch (_: Exception) {
+                // best-effort hardening
+            }
+            isNamespaceAware = false
+        }
+        val parser = factory.newSAXParser()
+        var currentPackage: String? = null
+        var currentFile: String? = null
+        try {
+            parser.parse(text.byteInputStream(), object : DefaultHandler() {
+                override fun startElement(uri: String?, localName: String?, qName: String, attrs: Attributes) {
+                    when (qName) {
+                        "package" -> currentPackage = attrs.getValue("name")
+                        "sourcefile" -> currentFile = attrs.getValue("name")
+                        "counter" -> {
+                            if (currentFile == null) return
+                            if (attrs.getValue("type") != "LINE") return
+                            val missed = attrs.getValue("missed")?.toIntOrNull() ?: return
+                            val covered = attrs.getValue("covered")?.toIntOrNull() ?: return
+                            val key = if (currentPackage.isNullOrBlank()) currentFile!!
+                                      else "$currentPackage/$currentFile"
+                            perFile[key] = FileCoverage(covered, covered + missed)
+                        }
+                    }
+                }
+
+                override fun endElement(uri: String?, localName: String?, qName: String) {
+                    when (qName) {
+                        "sourcefile" -> currentFile = null
+                        "package" -> currentPackage = null
+                    }
+                }
+            })
+        } catch (_: Exception) {
+            return null
+        }
+        if (perFile.isEmpty()) return null
+        return CoverageData(format, sourceLabel, perFile)
+    }
+}

--- a/src/main/kotlin/com/github/projectstats/coverage/LcovReader.kt
+++ b/src/main/kotlin/com/github/projectstats/coverage/LcovReader.kt
@@ -1,0 +1,60 @@
+package com.github.projectstats.coverage
+
+/**
+ * LCOV `.info` parser.
+ *
+ * LCOV is the most portable coverage format. It is emitted by Istanbul (JS/TS), c8, Vitest,
+ * Jest, Karma, gcov, llvm-cov, gcov2lcov (Go), grcov (Rust), Swift Package Manager, etc.
+ *
+ * The format is line-oriented; we only need:
+ *  - `SF:<file path>`  — start of a per-file record
+ *  - `DA:<line>,<hits>` — line execution count (hits == 0 → uncovered)
+ *  - `end_of_record`   — terminates a per-file record
+ *
+ * `LF:` (lines found) and `LH:` (lines hit) are summary fields that we recompute from `DA`
+ * to be tolerant of off-by-one errors in malformed reports.
+ */
+object LcovReader : CoverageReader {
+    override val format: CoverageFormat = CoverageFormat.LCOV
+
+    override fun parse(text: String, sourceLabel: String): CoverageData? {
+        if ("SF:" !in text) return null
+        val perFile = HashMap<String, FileCoverage>()
+        var currentFile: String? = null
+        var covered = 0
+        var coverable = 0
+        for (rawLine in text.lineSequence()) {
+            val line = rawLine.trim()
+            when {
+                line.startsWith("SF:") -> {
+                    currentFile = line.substring(3).trim()
+                    covered = 0
+                    coverable = 0
+                }
+                line.startsWith("DA:") -> {
+                    val payload = line.substring(3)
+                    val comma = payload.indexOf(',')
+                    if (comma > 0) {
+                        val hits = payload.substring(comma + 1).substringBefore(',').toIntOrNull() ?: 0
+                        coverable++
+                        if (hits > 0) covered++
+                    }
+                }
+                line == "end_of_record" -> {
+                    val f = currentFile
+                    if (f != null && coverable > 0) {
+                        // Merge if the same file appears more than once.
+                        val prev = perFile[f]
+                        perFile[f] = if (prev == null) FileCoverage(covered, coverable)
+                        else FileCoverage(prev.coveredLines + covered, prev.coverableLines + coverable)
+                    }
+                    currentFile = null
+                    covered = 0
+                    coverable = 0
+                }
+            }
+        }
+        if (perFile.isEmpty()) return null
+        return CoverageData(format, sourceLabel, perFile)
+    }
+}

--- a/src/test/kotlin/com/github/projectstats/coverage/CoberturaReaderTest.kt
+++ b/src/test/kotlin/com/github/projectstats/coverage/CoberturaReaderTest.kt
@@ -1,0 +1,42 @@
+package com.github.projectstats.coverage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CoberturaReaderTest {
+
+    @Test
+    fun `parses class lines`() {
+        val xml = """
+            <?xml version="1.0"?>
+            <coverage>
+              <packages>
+                <package name="foo">
+                  <classes>
+                    <class filename="src/foo/bar.py">
+                      <lines>
+                        <line number="1" hits="2"/>
+                        <line number="2" hits="0"/>
+                        <line number="3" hits="5"/>
+                      </lines>
+                    </class>
+                  </classes>
+                </package>
+              </packages>
+            </coverage>
+        """.trimIndent()
+        val data = CoberturaReader.parse(xml, "coverage.xml")
+        assertNotNull(data)
+        assertEquals(CoverageFormat.COBERTURA, data!!.format)
+        val cov = data.perFile["src/foo/bar.py"]!!
+        assertEquals(3, cov.coverableLines)
+        assertEquals(2, cov.coveredLines)
+    }
+
+    @Test
+    fun `returns null for non-cobertura input`() {
+        assertNull(CoberturaReader.parse("<other/>", "x"))
+    }
+}

--- a/src/test/kotlin/com/github/projectstats/coverage/CoverageMatcherTest.kt
+++ b/src/test/kotlin/com/github/projectstats/coverage/CoverageMatcherTest.kt
@@ -1,0 +1,58 @@
+package com.github.projectstats.coverage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class CoverageMatcherTest {
+
+    private fun data(vararg pairs: Pair<String, FileCoverage>) =
+        CoverageData(CoverageFormat.LCOV, "x", pairs.toMap())
+
+    @Test
+    fun `exact path match`() {
+        val m = CoverageMatcher(data("src/main/Foo.kt" to FileCoverage(2, 4)))
+        val cov = m.match("src/main/Foo.kt")!!
+        assertEquals(4, cov.coverableLines)
+    }
+
+    @Test
+    fun `suffix match handles absolute coverage paths`() {
+        val m = CoverageMatcher(data("/abs/build/src/main/Foo.kt" to FileCoverage(1, 3)))
+        val cov = m.match("src/main/Foo.kt")!!
+        assertEquals(3, cov.coverableLines)
+    }
+
+    @Test
+    fun `suffix match handles jacoco-style package keys`() {
+        val m = CoverageMatcher(data("com/example/foo/MyClass.kt" to FileCoverage(7, 10)))
+        val cov = m.match("src/main/kotlin/com/example/foo/MyClass.kt")!!
+        assertEquals(10, cov.coverableLines)
+    }
+
+    @Test
+    fun `prefers entry with more coverable lines on tie`() {
+        val m = CoverageMatcher(
+            data(
+                "a/Foo.kt" to FileCoverage(1, 2),
+                "b/Foo.kt" to FileCoverage(5, 10),
+            )
+        )
+        // Both end with "Foo.kt" suffix; the larger one wins.
+        val cov = m.match("Foo.kt")!!
+        assertEquals(10, cov.coverableLines)
+    }
+
+    @Test
+    fun `windows backslashes are normalised`() {
+        val m = CoverageMatcher(data("src/main/Foo.kt" to FileCoverage(1, 2)))
+        val cov = m.match("src\\main\\Foo.kt")!!
+        assertEquals(2, cov.coverableLines)
+    }
+
+    @Test
+    fun `returns null on miss`() {
+        val m = CoverageMatcher(data("Foo.kt" to FileCoverage(1, 2)))
+        assertNull(m.match("Bar.kt"))
+    }
+}

--- a/src/test/kotlin/com/github/projectstats/coverage/JacocoReaderTest.kt
+++ b/src/test/kotlin/com/github/projectstats/coverage/JacocoReaderTest.kt
@@ -1,0 +1,41 @@
+package com.github.projectstats.coverage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class JacocoReaderTest {
+
+    @Test
+    fun `parses LINE counters per sourcefile`() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <report name="demo">
+              <package name="com/example/foo">
+                <sourcefile name="MyClass.kt">
+                  <line nr="1" mi="0" ci="3"/>
+                  <counter type="INSTRUCTION" missed="2" covered="8"/>
+                  <counter type="LINE" missed="2" covered="8"/>
+                </sourcefile>
+                <sourcefile name="Other.kt">
+                  <counter type="LINE" missed="0" covered="4"/>
+                </sourcefile>
+              </package>
+            </report>
+        """.trimIndent()
+        val data = JacocoReader.parse(xml, "jacoco.xml")
+        assertNotNull(data)
+        val a = data!!.perFile["com/example/foo/MyClass.kt"]!!
+        assertEquals(10, a.coverableLines)
+        assertEquals(8, a.coveredLines)
+        val b = data.perFile["com/example/foo/Other.kt"]!!
+        assertEquals(4, b.coverableLines)
+        assertEquals(4, b.coveredLines)
+    }
+
+    @Test
+    fun `returns null for non-jacoco input`() {
+        assertNull(JacocoReader.parse("<coverage/>", "x"))
+    }
+}

--- a/src/test/kotlin/com/github/projectstats/coverage/LcovReaderTest.kt
+++ b/src/test/kotlin/com/github/projectstats/coverage/LcovReaderTest.kt
@@ -1,0 +1,52 @@
+package com.github.projectstats.coverage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class LcovReaderTest {
+
+    @Test
+    fun `parses single record`() {
+        val text = """
+            TN:
+            SF:src/main/kotlin/Foo.kt
+            DA:1,1
+            DA:2,0
+            DA:3,3
+            LF:3
+            LH:2
+            end_of_record
+        """.trimIndent()
+        val data = LcovReader.parse(text, "lcov.info")
+        assertNotNull(data)
+        assertEquals(CoverageFormat.LCOV, data!!.format)
+        val cov = data.perFile["src/main/kotlin/Foo.kt"]
+        assertNotNull(cov)
+        assertEquals(3, cov!!.coverableLines)
+        assertEquals(2, cov.coveredLines)
+    }
+
+    @Test
+    fun `merges duplicate SF entries`() {
+        val text = """
+            SF:Foo.kt
+            DA:1,1
+            DA:2,0
+            end_of_record
+            SF:Foo.kt
+            DA:3,5
+            end_of_record
+        """.trimIndent()
+        val data = LcovReader.parse(text, "lcov.info")!!
+        val cov = data.perFile["Foo.kt"]!!
+        assertEquals(3, cov.coverableLines)
+        assertEquals(2, cov.coveredLines)
+    }
+
+    @Test
+    fun `returns null for unrecognised input`() {
+        assertNull(LcovReader.parse("not lcov at all", "x"))
+    }
+}


### PR DESCRIPTION
Closes #14

Auto-discovers coverage reports anywhere under the project base and exposes per-file coverage as a first-class metric — no per-project configuration.

## Discovery (first match wins)
1. **LCOV** — `lcov.info` / `coverage/lcov.info` / `coverage.lcov`
2. **Cobertura** — `coverage.xml` / `cobertura-coverage.xml`
3. **JaCoCo** — `build/reports/jacoco/` or `target/site/jacoco/jacoco.xml` (multiple reports merged)

## Parsers (`coverage/`)
- `LcovReader` — streaming line parser; recomputes LF/LH from DA; merges duplicate SF entries
- `CoberturaReader` — SAX, XXE-hardened
- `JacocoReader` — SAX, XXE-hardened; uses `<counter type="LINE">` per `<sourcefile>` for accurate counts

## Path matching
`CoverageMatcher` builds a suffix index over coverage entries — tolerates absolute paths (LCOV), report-root-relative paths (Cobertura), and `package/file` keys (JaCoCo). Ties broken by larger `coverableLines`.

## Model & UI
- `FileStat` / `StatGroup` / `ScanResult` gain `coveredLines` + `coverableLines`
- `StatGroup.coverageFraction()`
- New `Metric.COVERED_LOC` and `Metric.UNCOVERED_LOC`
- `StatsAggregator` pipes coverage through `flatGroup` + `directoryTree`
- `ProjectScanner` attaches coverage post-classification
- `ProjectStatsPanel` shows the discovered report in the footer

## Tests
`LcovReaderTest`, `CoberturaReaderTest`, `JacocoReaderTest`, `CoverageMatcherTest` — all green via `./gradlew test`.